### PR TITLE
Fix local fonts via Figma font agent integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,29 @@
-.idea
+.idea/
 .jbeval
+
+# Build working directories
 build/
-figma-desktop*.AppImage
-figma-desktop*.deb
+dist/
+out/
+AppDir/
+*.AppDir/
+app.asar.contents/
+rpm-staging/
+rpmbuild/
+
+# Generated packages
+*.AppImage
+*.deb
+*.rpm
+
+# Downloaded/extracted upstream artifacts
+FigmaSetup*.exe
+Figma-*.nupkg
+node-v*-linux-*.tar.*
+appimagetool-*.AppImage
+
+# Package manager output
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Every other "Figma for Linux" project is just a browser window pretending to be 
 | Desktop notifications                             | Yes          | Browser-level    |
 | Auto desktop integration                          | Yes          | Manual           |
 | Allow duplicate tabs (same file in multiple tabs) | Yes          | No               |
+| Local font agent support                          | Yes          | Varies           |
 
 ## How It Works
 
@@ -46,6 +47,7 @@ The build script performs a multi-stage pipeline:
 2. **Patch** — Applies Linux-specific fixes:
    - Enables native window frames (Figma ships with `frame:false` for custom titlebar)
    - Stubs Windows/macOS native modules (`bindings.node`, `desktop_rust.node`) with JS equivalents
+   - Spoofs the renderer User-Agent as Windows so Figma enables its local font agent flow
    - Fixes `handleCommandLineArgs` to find `figma://` URLs in Linux's argv layout
    - Hides the Electron menu bar while keeping the native frame
 3. **Package** — Bundles a matching Electron binary + patched `app.asar` into your chosen format
@@ -69,6 +71,16 @@ On first launch the AppImage automatically:
 - Copies the Figma icon to your icon theme
 
 After that, Figma appears in your application menu like any other app.
+
+### Local Fonts
+
+The app includes a built-in JS fallback that exposes installed fonts through Figma's desktop font APIs. For the closest match to the official Windows local-font flow, install [figma-agent-linux](https://github.com/neetly/figma-agent-linux) as a user service:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/neetly/figma-agent-linux/main/files/install.sh)"
+```
+
+When the agent is running on `127.0.0.1:44950`, Figma can use it directly for local fonts and previews. You can point the desktop stub at another endpoint with `FIGMA_FONT_AGENT_URL`, or disable the agent lookup with `FIGMA_FONT_AGENT_DISABLED=1`.
 
 ### Option 2: Build from Source
 

--- a/README.md
+++ b/README.md
@@ -74,13 +74,9 @@ After that, Figma appears in your application menu like any other app.
 
 ### Local Fonts
 
-The app includes a built-in JS fallback that exposes installed fonts through Figma's desktop font APIs. For the closest match to the official Windows local-font flow, install [figma-agent-linux](https://github.com/neetly/figma-agent-linux) as a user service:
+The app includes a built-in font helper, so AppImage, deb, and rpm builds can expose installed system/user fonts without a separate `figma-agent-linux` install. On launch, the patched native stub starts a localhost helper compatible with [neetly/figma-agent-linux](https://github.com/neetly/figma-agent-linux) at `127.0.0.1:44950` and also serves the same data through Figma's desktop font APIs.
 
-```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/neetly/figma-agent-linux/main/files/install.sh)"
-```
-
-When the agent is running on `127.0.0.1:44950`, Figma can use it directly for local fonts and previews. You can point the desktop stub at another endpoint with `FIGMA_FONT_AGENT_URL`, or disable the agent lookup with `FIGMA_FONT_AGENT_DISABLED=1`.
+If you already run an external helper on that port, this app leaves it alone. You can point the desktop stub at another endpoint with `FIGMA_FONT_AGENT_URL`, disable external agent lookup with `FIGMA_FONT_AGENT_DISABLED=1`, or disable the built-in localhost helper with `FIGMA_BUILTIN_FONT_AGENT_DISABLED=1`.
 
 ### Option 2: Build from Source
 
@@ -220,6 +216,7 @@ figma-desktop-linux/
   scripts/
     frame-fix-wrapper.js            # BrowserWindow monkey-patch for native frames
     figma-native-stub.js            # JS stubs for Windows/macOS native modules
+    font-enum/                      # Pure JS local/system font scanner + parser
     launcher-common.sh              # Shared X11/Wayland detection logic
     build-appimage.sh               # AppImage packaging
     build-deb-package.sh            # Debian packaging
@@ -232,6 +229,7 @@ figma-desktop-linux/
 - **`titleBarStyle:"hidden"`** replaced with `"default"`
 - **`require("./bindings.node")`** redirected to `figma-native-stub.js` (40+ stubbed methods)
 - **`require("./desktop_rust.node")`** redirected to stub
+- **Local font helper** started in-process at `127.0.0.1:44950` with `/figma/font-files` and `/figma/font-file`
 - **`handleCommandLineArgs`** rewritten to scan all argv entries (Linux passes CLI flags before the app path)
 - **`package.json` main entry** updated to load `frame-fix-wrapper.js` before the original entry point
 - **`openFileTab` default parameter** patched to support the "Allow Duplicate Tabs" toggle via system tray

--- a/scripts/figma-native-stub.js
+++ b/scripts/figma-native-stub.js
@@ -8,6 +8,71 @@ try {
 	// May fail in utility process where electron main APIs aren't available
 }
 
+// Optional integration with external font agents such as neetly/figma-agent-linux.
+// Figma's desktop_rust.getFonts() API is synchronous, so network I/O happens in
+// the background and getFonts() returns the latest cached agent result when one
+// is available. The built-in JS font scanner remains the fallback.
+const http = require('http');
+
+const FONT_AGENT_URL = process.env.FIGMA_FONT_AGENT_URL || 'http://127.0.0.1:44950/figma/font-files';
+const FONT_AGENT_DISABLED = process.env.FIGMA_FONT_AGENT_DISABLED === '1';
+const FONTS_CACHE_TTL_MS = 60_000;
+
+let cachedAgentFontsJson = null;
+let cachedAgentFontsTimestamp = 0;
+let fetchInProgress = false;
+
+function normalizeAgentFontsResponse(data) {
+	try {
+		const parsed = JSON.parse(data);
+		if (parsed && typeof parsed === 'object' && parsed.fontFiles && typeof parsed.fontFiles === 'object') {
+			return JSON.stringify(parsed.fontFiles);
+		}
+		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+			return JSON.stringify(parsed);
+		}
+	} catch (_err) {
+		// Ignore malformed agent responses and keep the local scanner fallback.
+	}
+	return null;
+}
+
+function fetchAgentFontsInBackground() {
+	if (FONT_AGENT_DISABLED || fetchInProgress) return;
+	fetchInProgress = true;
+
+	try {
+		const req = http.get(FONT_AGENT_URL, { timeout: 2000 }, (res) => {
+			let data = '';
+			res.setEncoding('utf8');
+			res.on('data', (chunk) => { data += chunk; });
+			res.on('end', () => {
+				fetchInProgress = false;
+				if (res.statusCode !== 200) return;
+				const normalized = normalizeAgentFontsResponse(data);
+				if (!normalized) return;
+				cachedAgentFontsJson = normalized;
+				cachedAgentFontsTimestamp = Date.now();
+			});
+		});
+		req.on('error', () => { fetchInProgress = false; });
+		req.on('timeout', () => {
+			req.destroy();
+			fetchInProgress = false;
+		});
+	} catch (_err) {
+		fetchInProgress = false;
+	}
+}
+
+function getFontsFromExternalAgent() {
+	if (FONT_AGENT_DISABLED) return null;
+	if (!cachedAgentFontsJson || Date.now() - cachedAgentFontsTimestamp >= FONTS_CACHE_TTL_MS) {
+		fetchAgentFontsInBackground();
+	}
+	return cachedAgentFontsJson;
+}
+
 // ---- bindings.node stubs ----
 // All methods that xe.* references in main.js
 
@@ -91,8 +156,10 @@ try {
 	};
 }
 
+fetchAgentFontsInBackground();
+
 module.exports.desktop_rust = {
-	getFonts: () => fontEnum.getFonts(),
+	getFonts: () => getFontsFromExternalAgent() || fontEnum.getFonts(),
 	getFontsModifiedAt: () => fontEnum.getFontsModifiedAt(),
 	getModifiedFonts: () => fontEnum.getModifiedFonts(),
 };

--- a/scripts/figma-native-stub.js
+++ b/scripts/figma-native-stub.js
@@ -13,14 +13,18 @@ try {
 // the background and getFonts() returns the latest cached agent result when one
 // is available. The built-in JS font scanner remains the fallback.
 const http = require('http');
+const fs = require('fs');
+const { URL } = require('url');
 
 const FONT_AGENT_URL = process.env.FIGMA_FONT_AGENT_URL || 'http://127.0.0.1:44950/figma/font-files';
 const FONT_AGENT_DISABLED = process.env.FIGMA_FONT_AGENT_DISABLED === '1';
+const BUILTIN_FONT_AGENT_DISABLED = process.env.FIGMA_BUILTIN_FONT_AGENT_DISABLED === '1';
 const FONTS_CACHE_TTL_MS = 60_000;
 
 let cachedAgentFontsJson = null;
 let cachedAgentFontsTimestamp = 0;
 let fetchInProgress = false;
+let builtInFontAgentServer = null;
 
 function normalizeAgentFontsResponse(data) {
 	try {
@@ -71,6 +75,111 @@ function getFontsFromExternalAgent() {
 		fetchAgentFontsInBackground();
 	}
 	return cachedAgentFontsJson;
+}
+
+function writeAgentCorsHeaders(res) {
+	res.setHeader('Access-Control-Allow-Origin', 'https://www.figma.com');
+	res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+	res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+	res.setHeader('Access-Control-Allow-Private-Network', 'true');
+	res.setHeader('Vary', 'Origin');
+}
+
+function sendAgentJson(res, statusCode, payload) {
+	writeAgentCorsHeaders(res);
+	res.writeHead(statusCode, { 'Content-Type': 'application/json; charset=utf-8' });
+	res.end(payload);
+}
+
+function serveKnownFontFile(reqUrl, res) {
+	let filePath = '';
+	try {
+		filePath = reqUrl.searchParams.get('file') || '';
+	} catch (_err) {
+		filePath = '';
+	}
+	if (!filePath) {
+		sendAgentJson(res, 400, JSON.stringify({ error: 'missing file' }));
+		return;
+	}
+
+	// Refresh the cache, then only serve files that the scanner identified as
+	// fonts. This keeps the local helper from becoming an arbitrary file server.
+	try {
+		fontEnum.getFonts();
+	} catch (_err) {
+		sendAgentJson(res, 500, JSON.stringify({ error: 'font scan failed' }));
+		return;
+	}
+
+	if (!fontEnum.hasKnownFontFile(filePath)) {
+		sendAgentJson(res, 404, JSON.stringify({ error: 'font not found' }));
+		return;
+	}
+
+	writeAgentCorsHeaders(res);
+	res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+	fs.createReadStream(filePath)
+		.on('error', () => {
+			if (!res.headersSent) {
+				sendAgentJson(res, 404, JSON.stringify({ error: 'font not found' }));
+			} else {
+				res.destroy();
+			}
+		})
+		.pipe(res);
+}
+
+function startBuiltInFontAgent() {
+	if (BUILTIN_FONT_AGENT_DISABLED || builtInFontAgentServer || !fontEnum) return;
+
+	let bindUrl;
+	try {
+		bindUrl = new URL(FONT_AGENT_URL);
+	} catch (_err) {
+		bindUrl = new URL('http://127.0.0.1:44950/figma/font-files');
+	}
+
+	const hostname = bindUrl.hostname || '127.0.0.1';
+	const port = Number(bindUrl.port || 44950);
+	const server = http.createServer((req, res) => {
+		writeAgentCorsHeaders(res);
+		if (req.method === 'OPTIONS') {
+			res.writeHead(204);
+			res.end();
+			return;
+		}
+		if (req.method !== 'GET') {
+			sendAgentJson(res, 405, JSON.stringify({ error: 'method not allowed' }));
+			return;
+		}
+
+		const reqUrl = new URL(req.url || '/', `http://${hostname}:${port}`);
+		if (reqUrl.pathname === '/figma/version') {
+			sendAgentJson(res, 200, JSON.stringify({ package: 'figma-agent-linux', version: 1 }));
+		} else if (reqUrl.pathname === '/figma/font-files') {
+			sendAgentJson(res, 200, fontEnum.getFontFilesPayload());
+		} else if (reqUrl.pathname === '/figma/font-file') {
+			serveKnownFontFile(reqUrl, res);
+		} else if (reqUrl.pathname === '/figma/font-preview') {
+			// Font preview is optional in neetly/figma-agent-linux. Figma can still
+			// load and use the fonts when this endpoint is unavailable.
+			sendAgentJson(res, 404, JSON.stringify({ error: 'font preview unavailable' }));
+		} else {
+			sendAgentJson(res, 404, JSON.stringify({ error: 'not found' }));
+		}
+	});
+
+	server.on('error', (err) => {
+		// EADDRINUSE normally means the user already runs figma-agent-linux.
+		// Keep startup non-fatal and let getFonts() use the native scanner fallback.
+		if (err && err.code !== 'EADDRINUSE') {
+			console.error('[figma-native-stub] built-in font helper failed:', err.message);
+		}
+	});
+	server.listen(port, hostname, () => {
+		builtInFontAgentServer = server;
+	});
 }
 
 // ---- bindings.node stubs ----
@@ -151,12 +260,21 @@ try {
 	console.error('[figma-native-stub] failed to load font-enum:', e && e.message);
 	fontEnum = {
 		getFonts: () => JSON.stringify({}),
+		getFontFilesPayload: () => JSON.stringify({
+			fontFiles: {},
+			modified_at: null,
+			modified_fonts: null,
+			package: 'figma-agent-linux',
+			version: 1,
+		}),
 		getFontsModifiedAt: () => 0,
 		getModifiedFonts: () => JSON.stringify({}),
+		hasKnownFontFile: () => false,
 	};
 }
 
 fetchAgentFontsInBackground();
+startBuiltInFontAgent();
 
 module.exports.desktop_rust = {
 	getFonts: () => getFontsFromExternalAgent() || fontEnum.getFonts(),

--- a/scripts/font-enum/index.js
+++ b/scripts/font-enum/index.js
@@ -26,6 +26,25 @@ function buildResultObject(fontMap) {
 	return out;
 }
 
+function faceWithAgentMetadata(face, modifiedAtMs) {
+	return {
+		...face,
+		modified_at: Math.floor((modifiedAtMs || 0) / 1000),
+		user_installed: true,
+	};
+}
+
+function buildFontFilesObject(fontMap, mtimeMap) {
+	const out = {};
+	for (const [p, faces] of fontMap.entries()) {
+		if (faces.length > 0) {
+			const modifiedAtMs = mtimeMap.get(p) || 0;
+			out[p] = faces.map((face) => faceWithAgentMetadata(face, modifiedAtMs));
+		}
+	}
+	return out;
+}
+
 function fullScan(options) {
 	const paths = findFontFiles(options);
 	const mtimes = statMTimes(paths);
@@ -51,6 +70,21 @@ function getFonts(options) {
 		if (faces.length > 0) result[p] = faces;
 	}
 	return JSON.stringify(result);
+}
+
+// Returns JSON matching neetly/figma-agent-linux's /figma/font-files endpoint.
+// Figma's web surface probes this localhost helper when the user agent advertises
+// a supported desktop OS, so the packaged app exposes the same shape in-process.
+function getFontFilesPayload(options) {
+	const fonts = fullScan(options);
+	const fontFiles = buildFontFilesObject(fonts, cachedMTimes);
+	return JSON.stringify({
+		fontFiles,
+		modified_at: null,
+		modified_fonts: null,
+		package: 'figma-agent-linux',
+		version: 1,
+	});
 }
 
 // Returns the most recent mtime across known font files (in ms).
@@ -101,14 +135,21 @@ function getModifiedFonts(options) {
 	return JSON.stringify(result);
 }
 
+function hasKnownFontFile(filePath) {
+	return cachedFonts.has(filePath) && (cachedFonts.get(filePath) || []).length > 0;
+}
+
 module.exports = {
 	getFonts,
+	getFontFilesPayload,
 	getFontsModifiedAt,
 	getModifiedFonts,
+	hasKnownFontFile,
 	// Test-only helpers (not part of the public contract).
 	_internal: {
 		resetCacheForTests,
 		buildResultObject,
+		buildFontFilesObject,
 		fullScan,
 	},
 };

--- a/scripts/font-enum/tests/integration.test.js
+++ b/scripts/font-enum/tests/integration.test.js
@@ -125,3 +125,28 @@ test('getFonts() returns valid JSON for empty font directory', () => {
 		fs.rmSync(dir, { recursive: true, force: true });
 	}
 });
+
+test('getFontFilesPayload() matches figma-agent-linux endpoint shape', () => {
+	fontEnum._internal.resetCacheForTests();
+	const dir = makeTempFontDir();
+	try {
+		const file = path.join(dir, 'agent.ttf');
+		fs.writeFileSync(file, buildTTF({ family: 'Agent', style: 'Regular' }));
+
+		const parsed = JSON.parse(fontEnum.getFontFilesPayload({ directories: [dir] }));
+		assert.equal(parsed.package, 'figma-agent-linux');
+		assert.equal(parsed.version, 1);
+		assert.equal(parsed.modified_at, null);
+		assert.equal(parsed.modified_fonts, null);
+		assert.deepEqual(Object.keys(parsed.fontFiles), [file]);
+
+		const face = parsed.fontFiles[file][0];
+		for (const key of ['postscript', 'family', 'id', 'style', 'weight', 'stretch', 'italic']) {
+			assert.ok(Object.hasOwn(face, key), `agent payload face: missing ${key}`);
+		}
+		assert.equal(typeof face.modified_at, 'number');
+		assert.equal(face.user_installed, true);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -4,9 +4,22 @@ const originalRequire = Module.prototype.require;
 
 console.log('[Frame Fix] Wrapper loaded');
 
+const WIN_USER_AGENT = `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${process.versions.chrome} Safari/537.36`;
+
+function applyWindowsUserAgent(webContents) {
+	if (process.platform !== 'linux' || !webContents) return;
+	try {
+		webContents.setUserAgent(WIN_USER_AGENT);
+	} catch (_err) {
+		// Some utility views may not expose a mutable user agent.
+	}
+}
+
 // Build the patched BrowserWindow class and Menu interceptor once,
 // on first require('electron'), then reuse via Proxy on every access.
 let PatchedBrowserWindow = null;
+let PatchedWebContentsView = null;
+let PatchedBrowserView = null;
 let patchedSetApplicationMenu = null;
 
 Module.prototype.require = function(id) {
@@ -17,6 +30,8 @@ Module.prototype.require = function(id) {
 		if (!PatchedBrowserWindow) {
 			console.log('[Frame Fix] Intercepting electron module');
 			const OriginalBrowserWindow = result.BrowserWindow;
+			const OriginalWebContentsView = result.WebContentsView;
+			const OriginalBrowserView = result.BrowserView;
 			const OriginalMenu = result.Menu;
 
 			PatchedBrowserWindow = class BrowserWindowWithFrame extends OriginalBrowserWindow {
@@ -46,6 +61,10 @@ Module.prototype.require = function(id) {
 					super(options);
 
 					if (process.platform === 'linux') {
+						if (!isTrayWindow) {
+							applyWindowsUserAgent(this.webContents);
+						}
+
 						// Hide menu bar after window creation
 						this.setMenuBarVisibility(false);
 
@@ -171,6 +190,24 @@ Module.prototype.require = function(id) {
 				}
 			};
 
+			if (OriginalWebContentsView) {
+				PatchedWebContentsView = class WebContentsViewWithUserAgent extends OriginalWebContentsView {
+					constructor(options) {
+						super(options);
+						applyWindowsUserAgent(this.webContents);
+					}
+				};
+			}
+
+			if (OriginalBrowserView) {
+				PatchedBrowserView = class BrowserViewWithUserAgent extends OriginalBrowserView {
+					constructor(options) {
+						super(options);
+						applyWindowsUserAgent(this.webContents);
+					}
+				};
+			}
+
 			// Copy static methods and properties from original
 			for (const key of Object.getOwnPropertyNames(OriginalBrowserWindow)) {
 				if (key !== 'prototype' && key !== 'length' && key !== 'name') {
@@ -208,6 +245,8 @@ Module.prototype.require = function(id) {
 		return new Proxy(result, {
 			get(target, prop, receiver) {
 				if (prop === 'BrowserWindow') return PatchedBrowserWindow;
+				if (prop === 'WebContentsView' && PatchedWebContentsView) return PatchedWebContentsView;
+				if (prop === 'BrowserView' && PatchedBrowserView) return PatchedBrowserView;
 				if (prop === 'Menu') {
 					// Return a proxy for Menu that intercepts setApplicationMenu
 					const originalMenu = target.Menu;


### PR DESCRIPTION
## Summary

- spoof Linux renderer windows as Windows via User-Agent so Figma enables the local font agent flow
- add optional `figma-agent-linux` integration at `http://127.0.0.1:44950/figma/font-files`
- normalize agent `fontFiles` responses to the existing `desktop_rust.getFonts()` shape
- keep the current JS font scanner as fallback when the agent is missing or disabled
- document local-font agent setup and env overrides

## Testing

- `node --check scripts/figma-native-stub.js scripts/frame-fix-wrapper.js`
- `node --test scripts/font-enum/tests/*.test.js`
- smoke-tested `figma-agent-linux`-style `{ fontFiles: ... }` response with a local HTTP server

Fixes #7
