### PR TITLE
Update outdated AppImage runtime and build prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This covers the normal font picker and the **Installed by you** flow. If you alr
 
 #### Prerequisites
 
-- **Node.js 20+** (or the script installs it locally)
+- **Node.js 22.12+** (or the script installs it locally)
 - **p7zip** — for extracting the Windows installer
 - **ImageMagick** — for icon conversion
 - **wget** — for downloading the installer

--- a/build.sh
+++ b/build.sh
@@ -143,7 +143,7 @@ check_system_requirements() {
 
 	# Check for NVM and source it if found
 	if [[ -d $original_home/.nvm ]]; then
-		echo "Found NVM installation for user $original_user, checking for Node.js 20+..."
+		echo "Found NVM installation for user $original_user, checking for Node.js 22.12+..."
 		export NVM_DIR="$original_home/.nvm"
 		if [[ -s $NVM_DIR/nvm.sh ]]; then
 			# shellcheck disable=SC1091
@@ -244,7 +244,7 @@ parse_arguments() {
 check_dependencies() {
 	echo 'Checking dependencies...'
 	local deps_to_install=''
-	local common_deps='p7zip wget convert'
+	local common_deps='7z wget convert'
 	local all_deps="$common_deps"
 
 	# Add format-specific dependencies
@@ -255,12 +255,12 @@ check_dependencies() {
 
 	# Command-to-package mappings per distro family
 	declare -A debian_pkgs=(
-		[p7zip]='p7zip-full' [wget]='wget'
+		[7z]='p7zip-full' [wget]='wget'
 		[convert]='imagemagick'
 		[dpkg-deb]='dpkg-dev' [rpmbuild]='rpm'
 	)
 	declare -A rpm_pkgs=(
-		[p7zip]='p7zip p7zip-plugins' [wget]='wget'
+		[7z]='p7zip p7zip-plugins' [wget]='wget'
 		[convert]='ImageMagick'
 		[dpkg-deb]='dpkg' [rpmbuild]='rpm-build'
 	)
@@ -339,16 +339,18 @@ setup_nodejs() {
 
 	local node_version_ok=false
 	if command -v node &> /dev/null; then
-		local node_version node_major
+		local node_version node_major node_minor
 		node_version=$(node --version | cut -d'v' -f2)
 		node_major="${node_version%%.*}"
+		node_minor="${node_version#*.}"
+		node_minor="${node_minor%%.*}"
 		echo "System Node.js version: v$node_version"
 
-		if (( node_major >= 20 )); then
+		if (( node_major > 22 || (node_major == 22 && node_minor >= 12) )); then
 			echo "System Node.js version is adequate (v$node_version)"
 			node_version_ok=true
 		else
-			echo "System Node.js version is too old (v$node_version). Need v20+"
+			echo "System Node.js version is too old (v$node_version). Need v22.12+"
 		fi
 	else
 		echo 'Node.js not found in system'
@@ -360,10 +362,10 @@ setup_nodejs() {
 	fi
 
 	# Node.js version inadequate - install locally
-	echo 'Installing Node.js v20 locally in build directory...'
+	echo 'Installing Node.js v22 locally in build directory...'
 
 	local node_arch='x64'
-	local node_version_to_install='20.18.1'
+	local node_version_to_install='22.23.1'
 	local node_tarball="node-v${node_version_to_install}-linux-${node_arch}.tar.xz"
 	local node_url="https://nodejs.org/dist/v${node_version_to_install}/${node_tarball}"
 	local node_install_dir="$work_dir/node"

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -246,56 +246,73 @@ cat > "$metadata_dir/${component_id}.appdata.xml" << EOF
 EOF
 echo "AppStream metadata created"
 
-# --- Get appimagetool ---
-appimagetool_path=''
+# --- Get appimagetool and Type-2 runtime ---
+# Pin and verify both artifacts. The maintained appimagetool otherwise downloads
+# a moving, unverified runtime during each build.
+readonly appimagetool_version='1.9.1'
+readonly runtime_version='20251108'
 
-if command -v appimagetool &> /dev/null; then
-	appimagetool_path=$(command -v appimagetool)
-	echo "Found appimagetool in PATH: $appimagetool_path"
-fi
+case "$architecture" in
+	amd64)
+		tool_arch='x86_64'
+		appimagetool_sha256='ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0'
+		runtime_sha256='2fca8b443c92510f1483a883f60061ad09b46b978b2631c807cd873a47ec260d'
+		;;
+	arm64)
+		tool_arch='aarch64'
+		appimagetool_sha256='f0837e7448a0c1e4e650a93bb3e85802546e60654ef287576f46c71c126a9158'
+		runtime_sha256='00cbdfcf917cc6c0ff6d3347d59e0ca1f7f45a6df1a428a0d6d8a78664d87444'
+		;;
+	*)
+		echo "Unsupported architecture for appimagetool: $architecture" >&2
+		exit 1
+		;;
+esac
 
-for arch in x86_64 aarch64; do
-	[[ -n $appimagetool_path ]] && break
-	local_path="$work_dir/appimagetool-${arch}.AppImage"
-	if [[ -f $local_path ]]; then
-		appimagetool_path="$local_path"
-		echo "Found downloaded ${arch} appimagetool: $appimagetool_path"
+download_verified() {
+	local url="$1"
+	local output="$2"
+	local expected_sha256="$3"
+
+	if [[ -f $output ]] && printf '%s  %s\n' "$expected_sha256" "$output" | sha256sum --check --status; then
+		echo "Using verified cached artifact: $output"
+		return
 	fi
-done
 
-if [[ -z $appimagetool_path ]]; then
-	echo 'Downloading appimagetool...'
-	case "$architecture" in
-		amd64) tool_arch='x86_64' ;;
-		arm64) tool_arch='aarch64' ;;
-		*)
-			echo "Unsupported architecture for appimagetool: $architecture" >&2
-			exit 1
-			;;
-	esac
-
-	appimagetool_url="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${tool_arch}.AppImage"
-	appimagetool_path="$work_dir/appimagetool-${tool_arch}.AppImage"
-
-	if wget -q -O "$appimagetool_path" "$appimagetool_url"; then
-		chmod +x "$appimagetool_path" || exit 1
-		echo "Downloaded appimagetool to $appimagetool_path"
-	else
-		echo "Failed to download appimagetool from $appimagetool_url" >&2
-		rm -f "$appimagetool_path"
+	echo "Downloading $url"
+	rm -f "$output"
+	if ! wget -q -O "$output" "$url"; then
+		echo "Failed to download $url" >&2
+		rm -f "$output"
 		exit 1
 	fi
-fi
+	if ! printf '%s  %s\n' "$expected_sha256" "$output" | sha256sum --check --status; then
+		echo "Checksum verification failed for $output" >&2
+		rm -f "$output"
+		exit 1
+	fi
+}
+
+appimagetool_path="$work_dir/appimagetool-${appimagetool_version}-${tool_arch}.AppImage"
+runtime_path="$work_dir/runtime-${runtime_version}-${tool_arch}"
+download_verified \
+	"https://github.com/AppImage/appimagetool/releases/download/${appimagetool_version}/appimagetool-${tool_arch}.AppImage" \
+	"$appimagetool_path" "$appimagetool_sha256"
+download_verified \
+	"https://github.com/AppImage/type2-runtime/releases/download/${runtime_version}/runtime-${tool_arch}" \
+	"$runtime_path" "$runtime_sha256"
+chmod +x "$appimagetool_path" || exit 1
 
 # --- Build AppImage ---
 echo 'Building AppImage...'
 output_filename="${package_name}-${version}-${architecture}.AppImage"
 output_path="$work_dir/$output_filename"
-export ARCH="$architecture"
+export ARCH="$tool_arch"
 echo "Using ARCH=$ARCH"
 
 echo 'Building AppImage without update information'
-if ! "$appimagetool_path" "$appdir_path" "$output_path"; then
+if ! APPIMAGE_EXTRACT_AND_RUN=1 "$appimagetool_path" \
+	--runtime-file "$runtime_path" "$appdir_path" "$output_path"; then
 	echo "Failed to build AppImage using $appimagetool_path" >&2
 	exit 1
 fi


### PR DESCRIPTION
Thank you so much for this project! After struggling to run Figma with Wine on Linux for a long time, I was incredibly relieved when I found it.

One thing I noticed was the use of libfuse.so.2, which was not installed on my system. Here is a driveby fix for that.

## Summary

The current AppImage packaging is outdated: it downloads appimagetool from the obsolete AppImageKit continuous release and generates an AppImage whose runtime requires the legacy system library libfuse.so.2.

This PR moves packaging to the maintained AppImage tooling and static Type-2 runtime. The resulting AppImage no longer depends on the host providing FUSE 2.

It also updates other stale build prerequisites exposed by a complete build against the current Figma Desktop release.

## Why this update is needed

The existing build still uses:

AppImage/AppImageKit/releases/download/continuous/appimagetool-...

That is the legacy distribution of appimagetool. Its generated runtime dynamically loads libfuse.so.2.

This no longer matches the state of current Linux distributions:

- FUSE 3 is now the default on many distributions.
- FUSE 2 is deprecated or no longer installed by default.
- Some current distributions have removed FUSE 2 packages entirely.
- Users therefore cannot run the generated AppImage without installing an old compatibility library.

The AppImage project now maintains appimagetool and its static Type-2 runtime in separate repositories. The static runtime includes the necessary FUSE support and does not require libfuse.so.2 from the host.

The existing Node.js requirement is outdated as well. Current Figma Desktop 126.6.14 uses Electron 42.6.1, whose installer requires Node.js 22.12 or newer. The previous Node.js 20 bootstrap fails while installing the current Electron
platform binary.

## Changes

- Replace the obsolete AppImageKit continuous artifact with:
- appimagetool 1.9.1
- Type-2 runtime 20251108

- Pin both artifacts to immutable releases.
- Verify downloads against their upstream SHA-256 digests.
- Pass the runtime explicitly using --runtime-file.
- Avoid the maintained tool’s otherwise unpinned runtime download.
- Map package architecture names to the names expected by AppImage:
- amd64 → x86_64
- arm64 → aarch64

- Run appimagetool in extract-and-run mode so the build host does not need FUSE.
- Raise the Node.js minimum from 20 to 22.12.
- Update the local bootstrap from Node.js 20.18.1 to 22.23.1.
- Check for the 7z executable rather than a command named p7zip.

The 7z adjustment does not change distro package selection. p7zip is a package name, while 7z is the executable that the build invokes. The previous check produced false missing-dependency results and relied on package installation to
mask the mismatch.

## Verification

Tested with a complete build of the current Figma Desktop release:

Figma Desktop: 126.6.14
Electron:      42.6.1
Node.js:       22.23.1

Results:

- Full AppImage build completed successfully.
- Generated AppImage is a statically linked PIE executable.
- No libfuse.so.2 reference is present.
- AppImage extraction succeeded.
- Direct FUSE mounting succeeded.
- Figma launched successfully and remained running until the test timeout.

## AI assistance notice

This change was developed with assistance from OpenAI Codex.