### PR TITLE
feat: add Arch pacman/AUR support

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,0 +1,22 @@
+pkgbase = figma-desktop-bin
+	pkgdesc = Figma Desktop for Linux (patched Windows build, incl. FigJam and local font support)
+	pkgver = 126.5.6
+	pkgrel = 1
+	url = https://github.com/soroushalinia/figma-linux
+	arch = x86_64
+	license = custom:Figma-EULA
+	depends = fuse2
+	depends = zlib
+	depends = hicolor-icon-theme
+	depends = gtk3
+	depends = nss
+	depends = libxcrypt-compat
+	provides = figma-desktop
+	conflicts = figma-desktop
+	options = !strip
+	source = figma-desktop-126.5.6-amd64.AppImage::https://github.com/IliyaBrook/figma-linux/releases/download/126.5.6/figma-desktop-126.5.6-amd64.AppImage
+	source = figma-desktop.desktop
+	sha256sums = 48b9f8cbe35509c04366b1aa2299a920441abd8ef19e0b7924c23cc86d60ebfd
+	sha256sums = 5c0a875a0d414fd8c92e596736707e079a24a03de235f197f38f65b491688df3
+
+pkgname = figma-desktop-bin

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@ rpmbuild/
 *.AppImage
 *.deb
 *.rpm
+*.pkg.tar.zst
+*.pkg.tar.zst.sig
+
+# makepkg artifacts (AUR)
+src/
+pkg/
 
 # Downloaded/extracted upstream artifacts
 FigmaSetup*.exe

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APPIMAGE := $(wildcard figma-desktop-*.AppImage)
 
-.PHONY: build build-deb build-rpm build-appimage run run-debug clean url
+.PHONY: build build-deb build-rpm build-pacman build-appimage run run-debug clean url
 
 build: build-appimage
 
@@ -9,6 +9,9 @@ build-deb:
 
 build-rpm:
 	./build.sh --build rpm --clean no
+
+build-pacman:
+	./build.sh --build pacman --clean no
 
 build-appimage:
 	./build.sh --build appimage --clean no
@@ -27,9 +30,12 @@ endif
 
 clean:
 	rm -rf build/
+	rm -rf src/ pkg/
 	rm -f figma-desktop-*.AppImage
 	rm -f figma-desktop_*.deb
 	rm -f figma-desktop-*.rpm
+	rm -f figma-desktop-*.pkg.tar.zst
+	rm -f figma-desktop-*.pkg.tar.zst.sig
 
 url:
 	./figma-version-tool.sh

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Soroush Alinia <soroush.alinia.dev@gmail.com>
+pkgname=figma-desktop-bin
+pkgver=126.5.6
+pkgrel=1
+pkgdesc="Figma Desktop for Linux (patched Windows build, incl. FigJam and local font support)"
+arch=('x86_64')
+url="https://github.com/soroushalinia/figma-linux"
+license=('custom:Figma-EULA')
+depends=('fuse2' 'zlib' 'hicolor-icon-theme' 'gtk3' 'nss' 'libxcrypt-compat')
+options=('!strip')
+provides=('figma-desktop')
+conflicts=('figma-desktop')
+source=("figma-desktop-126.5.6-amd64.AppImage::https://github.com/IliyaBrook/figma-linux/releases/download/126.5.6/figma-desktop-126.5.6-amd64.AppImage"
+        "figma-desktop.desktop")
+sha256sums=('48b9f8cbe35509c04366b1aa2299a920441abd8ef19e0b7924c23cc86d60ebfd'
+            '5c0a875a0d414fd8c92e596736707e079a24a03de235f197f38f65b491688df3')
+
+prepare() {
+  chmod +x "${srcdir}/figma-desktop-126.5.6-amd64.AppImage"
+}
+
+package() {
+  # Install AppImage
+  install -dm755 "${pkgdir}/opt/figma-desktop"
+  install -Dm755 "${srcdir}/figma-desktop-126.5.6-amd64.AppImage" "${pkgdir}/opt/figma-desktop/figma-desktop.AppImage"
+
+  # Extract and install icon from the AppImage itself
+  cd "${srcdir}"
+  "${srcdir}/figma-desktop-126.5.6-amd64.AppImage" --appimage-extract >/dev/null 2>&1 || true
+  if [ -f "squashfs-root/figma-desktop.png" ]; then
+    install -Dm644 "squashfs-root/figma-desktop.png" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/figma-desktop.png"
+  elif [ -f "squashfs-root/.DirIcon" ]; then
+    install -Dm644 "squashfs-root/.DirIcon" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/figma-desktop.png"
+  elif [ -f "squashfs-root/io.github.nickvdp.figma-desktop-linux.png" ]; then
+    install -Dm644 "squashfs-root/io.github.nickvdp.figma-desktop-linux.png" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/figma-desktop.png"
+  fi
+  rm -rf "squashfs-root"
+
+  # Desktop entry
+  install -Dm644 "${srcdir}/figma-desktop.desktop" "${pkgdir}/usr/share/applications/figma-desktop.desktop"
+
+  # Symlink
+  install -dm755 "${pkgdir}/usr/bin"
+  ln -s "/opt/figma-desktop/figma-desktop.AppImage" "${pkgdir}/usr/bin/figma-desktop"
+}

--- a/build.sh
+++ b/build.sh
@@ -103,6 +103,9 @@ detect_distro() {
 	if [[ -f /etc/debian_version ]]; then
 		distro_family='debian'
 		echo "Detected Debian-based distribution"
+	elif [[ -f /etc/arch-release ]]; then
+		distro_family='arch'
+		echo "Detected Arch-based distribution"
 	elif [[ -f /etc/fedora-release ]]; then
 		distro_family='rpm'
 		echo "Detected Fedora"
@@ -112,7 +115,7 @@ detect_distro() {
 	else
 		distro_family='unknown'
 		echo "Warning: Could not detect distribution family"
-		echo "  AppImage build will still work, but native packages (deb/rpm) may not"
+		echo "  AppImage build will still work, but native packages (deb/rpm/pacman) may not"
 	fi
 
 	echo "Distribution: $(grep 'PRETTY_NAME' /etc/os-release 2>/dev/null | cut -d'"' -f2 || echo 'Unknown')"
@@ -179,6 +182,7 @@ parse_arguments() {
 	# Set default build format based on detected distro
 	case "$distro_family" in
 		debian) build_format='deb' ;;
+		arch) build_format='pacman' ;;
 		rpm) build_format='rpm' ;;
 		*) build_format='appimage' ;;
 	esac
@@ -198,8 +202,8 @@ parse_arguments() {
 				shift 2
 				;;
 			-h|--help)
-				echo "Usage: $0 [--build deb|rpm|appimage] [--clean yes|no] [--exe /path/to/FigmaSetup.exe]"
-				echo '  --build: Specify the build format (deb, rpm, or appimage).'
+				echo "Usage: $0 [--build deb|rpm|pacman|appimage] [--clean yes|no] [--exe /path/to/FigmaSetup.exe]"
+				echo '  --build: Specify the build format (deb, rpm, pacman, or appimage).'
 				echo "           Default: auto-detected based on distro (current: $build_format)"
 				echo '  --clean: Specify whether to clean intermediate build files (yes or no). Default: yes'
 				echo '  --exe:   Use a local Figma installer exe instead of downloading'
@@ -217,8 +221,8 @@ parse_arguments() {
 	build_format="${build_format,,}"
 	cleanup_action="${cleanup_action,,}"
 
-	if [[ $build_format != 'deb' && $build_format != 'rpm' && $build_format != 'appimage' ]]; then
-		echo "Invalid build format specified: '$build_format'. Must be 'deb', 'rpm', or 'appimage'." >&2
+	if [[ $build_format != 'deb' && $build_format != 'rpm' && $build_format != 'pacman' && $build_format != 'appimage' ]]; then
+		echo "Invalid build format specified: '$build_format'. Must be 'deb', 'rpm', 'pacman', or 'appimage'." >&2
 		exit 1
 	fi
 
@@ -227,6 +231,8 @@ parse_arguments() {
 		echo "Warning: Building .deb package on non-Debian system ($distro_family). This may fail." >&2
 	elif [[ $build_format == 'rpm' && $distro_family != 'rpm' ]]; then
 		echo "Warning: Building .rpm package on non-RPM system ($distro_family). This may fail." >&2
+	elif [[ $build_format == 'pacman' && $distro_family != 'arch' ]]; then
+		echo "Warning: Building pacman package on non-Arch system ($distro_family). This may fail." >&2
 	fi
 	if [[ $cleanup_action != 'yes' && $cleanup_action != 'no' ]]; then
 		echo "Invalid cleanup option specified: '$cleanup_action'. Must be 'yes' or 'no'." >&2
@@ -251,18 +257,24 @@ check_dependencies() {
 	case "$build_format" in
 		deb) all_deps="$all_deps dpkg-deb" ;;
 		rpm) all_deps="$all_deps rpmbuild" ;;
+		pacman) all_deps="$all_deps makepkg" ;;
 	esac
 
 	# Command-to-package mappings per distro family
 	declare -A debian_pkgs=(
 		[p7zip]='p7zip-full' [wget]='wget'
 		[convert]='imagemagick'
-		[dpkg-deb]='dpkg-dev' [rpmbuild]='rpm'
+		[dpkg-deb]='dpkg-dev' [rpmbuild]='rpm' [makepkg]='pacman'
 	)
 	declare -A rpm_pkgs=(
 		[p7zip]='p7zip p7zip-plugins' [wget]='wget'
 		[convert]='ImageMagick'
-		[dpkg-deb]='dpkg' [rpmbuild]='rpm-build'
+		[dpkg-deb]='dpkg' [rpmbuild]='rpm-build' [makepkg]='pacman'
+	)
+	declare -A arch_pkgs=(
+		[p7zip]='p7zip' [wget]='wget'
+		[convert]='imagemagick'
+		[dpkg-deb]='dpkg' [rpmbuild]='rpm-tools' [makepkg]='pacman'
 	)
 
 	local cmd
@@ -274,6 +286,9 @@ check_dependencies() {
 					;;
 				rpm)
 					deps_to_install="$deps_to_install ${rpm_pkgs[$cmd]}"
+					;;
+				arch)
+					deps_to_install="$deps_to_install ${arch_pkgs[$cmd]}"
 					;;
 				*)
 					echo "Warning: Cannot auto-install '$cmd' on unknown distro. Please install manually." >&2
@@ -314,6 +329,13 @@ check_dependencies() {
 				# shellcheck disable=SC2086
 				if ! $sudo_cmd dnf install -y $deps_to_install; then
 					echo "Failed to install dependencies using 'dnf install'." >&2
+					exit 1
+				fi
+				;;
+			arch)
+				# shellcheck disable=SC2086
+				if ! $sudo_cmd pacman -S --noconfirm $deps_to_install; then
+					echo "Failed to install dependencies using 'pacman -S'." >&2
 					exit 1
 				fi
 				;;
@@ -1275,13 +1297,17 @@ run_packaging() {
 			script_name='build-rpm-package.sh'
 			file_pattern="${PACKAGE_NAME}-${version}*.rpm"
 			;;
+		pacman)
+			script_name='build-pacman-package.sh'
+			file_pattern="*.pkg.tar.zst"
+			;;
 		appimage)
 			script_name='build-appimage.sh'
 			file_pattern="${PACKAGE_NAME}-${version}-${architecture}.AppImage"
 			;;
 	esac
 
-	if [[ $build_format == 'deb' || $build_format == 'rpm' ]]; then
+	if [[ $build_format == 'deb' || $build_format == 'rpm' || $build_format == 'pacman' ]]; then
 		echo "Calling ${build_format^^} packaging script for $architecture..."
 		chmod +x "scripts/$script_name" || exit 1
 		if ! "scripts/$script_name" \
@@ -1297,6 +1323,12 @@ run_packaging() {
 			output_path="./$(basename "$pkg_file")"
 			mv "$pkg_file" "$output_path" || exit 1
 			echo "Package created at: $output_path"
+			# pacman also generates PKGBUILD/.SRCINFO in repo root for AUR
+			if [[ $build_format == 'pacman' ]]; then
+				[[ -f "$work_dir/PKGBUILD" ]] && cp "$work_dir/PKGBUILD" ./PKGBUILD
+				[[ -f "$work_dir/.SRCINFO" ]] && cp "$work_dir/.SRCINFO" ./.SRCINFO
+				[[ -f "$work_dir/figma-desktop.desktop" ]] && cp "$work_dir/figma-desktop.desktop" ./figma-desktop.desktop
+			fi
 		else
 			echo "Warning: Could not determine final .${build_format} file path."
 			output_path='Not Found'
@@ -1347,21 +1379,28 @@ print_next_steps() {
 	echo -e '\n\033[1;34m====== Next Steps ======\033[0m'
 
 	case "$build_format" in
-		deb|rpm)
+		deb|rpm|pacman)
 			if [[ $final_output_path != 'Not Found' && -e $final_output_path ]]; then
 				local pkg_type install_cmd alt_cmd
 				if [[ $build_format == 'deb' ]]; then
 					pkg_type='Debian'
 					install_cmd="sudo apt install $final_output_path"
 					alt_cmd="sudo dpkg -i $final_output_path"
-				else
+				elif [[ $build_format == 'rpm' ]]; then
 					pkg_type='RPM'
 					install_cmd="sudo dnf install $final_output_path"
 					alt_cmd="sudo rpm -i $final_output_path"
+				else
+					pkg_type='Pacman'
+					install_cmd="sudo pacman -U $final_output_path"
+					alt_cmd="makepkg -si (from AUR: figma-desktop-bin)"
 				fi
 				echo -e "To install the $pkg_type package, run:"
 				echo -e "   \033[1;32m$install_cmd\033[0m"
 				echo -e "   (or \`$alt_cmd\`)"
+				if [[ $build_format == 'pacman' ]]; then
+					echo -e "AUR files: PKGBUILD + .SRCINFO + figma-desktop.desktop updated in repo root"
+				fi
 			else
 				echo -e "${build_format^^} package file not found. Cannot provide installation instructions."
 			fi

--- a/figma-desktop.desktop
+++ b/figma-desktop.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Figma
+Exec=/usr/bin/figma-desktop %u
+Icon=figma-desktop
+Type=Application
+Terminal=false
+Categories=Graphics;Development;
+MimeType=x-scheme-handler/figma;
+StartupWMClass=Figma
+Comment=Figma Desktop for Linux

--- a/scripts/build-pacman-package.sh
+++ b/scripts/build-pacman-package.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Build Arch Linux pacman package (.pkg.tar.zst) and AUR metadata
+# Mirrors build-deb-package.sh / build-rpm-package.sh for Arch
+# Usage: build-pacman-package.sh <version> <architecture> <work_dir> <app_staging_dir> <package_name> <maintainer> <description>
+# Produces:
+#   - $work_dir/PKGBUILD  (+ .SRCINFO) for AUR (figma-desktop-bin, AppImage wrapper)
+#   - $work_dir/*.pkg.tar.zst if makepkg is available
+#   - ./PKGBUILD + ./.SRCINFO updated in repo root for PR/AUR submission
+
+set -e
+
+version="$1"
+architecture="$2"
+work_dir="$3"
+app_staging_dir="$4"
+package_name="$5"   # figma-desktop (native) but AUR package is figma-desktop-bin
+maintainer="$6"
+description="$7"
+
+echo '--- Starting Pacman Package Build ---'
+echo "Version: $version"
+echo "Architecture: $architecture"
+echo "Work Directory: $work_dir"
+echo "App Staging Directory: $app_staging_dir"
+echo "Package Name: $package_name"
+echo "Maintainer: $maintainer"
+
+# Arch mapping (build.sh uses amd64)
+case "$architecture" in
+  amd64) pacman_arch='x86_64' ;;
+  arm64) pacman_arch='aarch64' ;;
+  x86_64) pacman_arch='x86_64'; architecture='amd64' ;;
+  aarch64) pacman_arch='aarch64'; architecture='arm64' ;;
+  *) echo "Unsupported architecture for pacman: $architecture" >&2; exit 1 ;;
+esac
+
+# We build figma-desktop-bin (AppImage wrapper) for AUR — consistent with user's draft
+aur_pkgname='figma-desktop-bin'
+aur_pkgver="$version"
+aur_pkgrel=1
+
+# Resolve repo URL from git remote if possible, else fallback to soroushalinia/figma-linux
+repo_url="https://github.com/soroushalinia/figma-linux"
+if git remote get-url origin &>/dev/null; then
+  remote=$(git remote get-url origin)
+  # git@github.com:user/repo.git -> https://github.com/user/repo
+  if [[ $remote == git@github.com:* ]]; then
+    remote=${remote#git@github.com:}
+    remote=${remote%.git}
+    repo_url="https://github.com/$remote"
+  elif [[ $remote == https://github.com/* ]]; then
+    remote=${remote%.git}
+    repo_url="$remote"
+  fi
+fi
+echo "Repo URL: $repo_url"
+
+# AppImage file produced by build-appimage.sh — hosted on upstream (IliyaBrook) releases
+# AppImage is published without `v` prefix: .../releases/download/<version>/<name>
+appimage_name="${package_name}-${version}-${architecture}.AppImage"
+appimage_path="$work_dir/$appimage_name"
+upstream_url="https://github.com/IliyaBrook/figma-linux/releases/download/${version}/${appimage_name}"
+# For your fork, replace with ${repo_url}/releases/download/${version}/${appimage_name} once you publish
+appimage_url="$upstream_url"
+
+# Try to compute sha256 of existing AppImage (for PKGBUILD), else placeholder that makepkg will refresh
+appimage_sha="SKIP"
+if [[ -f $appimage_path ]]; then
+  echo "Found AppImage at $appimage_path — computing sha256..."
+  appimage_sha=$(sha256sum "$appimage_path" | awk '{print $1}')
+  echo "AppImage sha256: $appimage_sha"
+else
+  echo "Warning: AppImage not found at $appimage_path — PKGBUILD will use SKIP (run makepkg -g after release upload)"
+  # Try to find any AppImage in work_dir as fallback
+  fallback=$(find "$work_dir" -maxdepth 1 -name "*.AppImage" | head -n 1)
+  if [[ -n $fallback ]]; then
+    appimage_sha=$(sha256sum "$fallback" | awk '{print $1}')
+    appimage_name=$(basename "$fallback")
+    appimage_url="https://github.com/IliyaBrook/figma-linux/releases/download/${version}/${appimage_name}"
+    echo "Using fallback $fallback sha $appimage_sha"
+  fi
+fi
+
+# Desktop file content — shared with deb/rpm, kept in repo root for AUR
+desktop_file_src="$work_dir/figma-desktop.desktop"
+cat > "$desktop_file_src" << 'DESKTOP'
+[Desktop Entry]
+Name=Figma
+Exec=/usr/bin/figma-desktop %u
+Icon=figma-desktop
+Type=Application
+Terminal=false
+Categories=Graphics;Development;
+MimeType=x-scheme-handler/figma;
+StartupWMClass=Figma
+Comment=Figma Desktop for Linux
+DESKTOP
+desktop_sha=$(sha256sum "$desktop_file_src" | awk '{print $1}')
+
+# --- Generate PKGBUILD for AUR (figma-desktop-bin) ---
+# Use script dir to resolve launcher is not needed for AppImage wrapper, but keep PKGBUILD self-contained
+pkgbuild_path="$work_dir/PKGBUILD"
+cat > "$pkgbuild_path" << PKGEOF
+# Maintainer: $maintainer
+pkgname=$aur_pkgname
+pkgver=$aur_pkgver
+pkgrel=$aur_pkgrel
+pkgdesc="$description (patched Windows build, incl. FigJam and local font support)"
+arch=('$pacman_arch')
+url="$repo_url"
+license=('custom:Figma-EULA')
+depends=('fuse2' 'zlib' 'hicolor-icon-theme' 'gtk3' 'nss' 'libxcrypt-compat')
+options=('!strip')
+provides=('figma-desktop')
+conflicts=('figma-desktop')
+source=("$appimage_name::${appimage_url}"
+        "figma-desktop.desktop")
+sha256sums=('$appimage_sha'
+            '$desktop_sha')
+
+prepare() {
+  chmod +x "\${srcdir}/$appimage_name"
+}
+
+package() {
+  # Install AppImage
+  install -dm755 "\${pkgdir}/opt/figma-desktop"
+  install -Dm755 "\${srcdir}/$appimage_name" "\${pkgdir}/opt/figma-desktop/figma-desktop.AppImage"
+
+  # Extract and install icon from the AppImage itself
+  cd "\${srcdir}"
+  "\${srcdir}/$appimage_name" --appimage-extract >/dev/null 2>&1 || true
+  if [ -f "squashfs-root/figma-desktop.png" ]; then
+    install -Dm644 "squashfs-root/figma-desktop.png" "\${pkgdir}/usr/share/icons/hicolor/512x512/apps/figma-desktop.png"
+  elif [ -f "squashfs-root/.DirIcon" ]; then
+    install -Dm644 "squashfs-root/.DirIcon" "\${pkgdir}/usr/share/icons/hicolor/512x512/apps/figma-desktop.png"
+  elif [ -f "squashfs-root/io.github.nickvdp.figma-desktop-linux.png" ]; then
+    install -Dm644 "squashfs-root/io.github.nickvdp.figma-desktop-linux.png" "\${pkgdir}/usr/share/icons/hicolor/512x512/apps/figma-desktop.png"
+  fi
+  rm -rf "squashfs-root"
+
+  # Desktop entry
+  install -Dm644 "\${srcdir}/figma-desktop.desktop" "\${pkgdir}/usr/share/applications/figma-desktop.desktop"
+
+  # Symlink
+  install -dm755 "\${pkgdir}/usr/bin"
+  ln -s "/opt/figma-desktop/figma-desktop.AppImage" "\${pkgdir}/usr/bin/figma-desktop"
+}
+PKGEOF
+
+echo "PKGBUILD generated at $pkgbuild_path"
+cat "$pkgbuild_path"
+
+# Desktop file already at $desktop_file_src == $work_dir/figma-desktop.desktop, no copy needed
+
+# --- Generate .SRCINFO ---
+srcinfo_path="$work_dir/.SRCINFO"
+if command -v makepkg &>/dev/null; then
+  echo "Generating .SRCINFO via makepkg --printsrcinfo..."
+  (cd "$work_dir" && makepkg --printsrcinfo > "$srcinfo_path")
+else
+  echo "makepkg not found — generating .SRCINFO manually..."
+  cat > "$srcinfo_path" << SRCEOF
+pkgbase = $aur_pkgname
+	pkgdesc = $description (patched Windows build, incl. FigJam and local font support)
+	pkgver = $aur_pkgver
+	pkgrel = $aur_pkgrel
+	url = $repo_url
+	arch = $pacman_arch
+	license = custom:Figma-EULA
+	depends = fuse2
+	depends = zlib
+	depends = hicolor-icon-theme
+	depends = gtk3
+	depends = nss
+	depends = libxcrypt-compat
+	provides = figma-desktop
+	conflicts = figma-desktop
+	options = !strip
+	source = $appimage_name::${appimage_url}
+	source = figma-desktop.desktop
+	sha256sums = $appimage_sha
+	sha256sums = $desktop_sha
+
+pkgname = $aur_pkgname
+SRCEOF
+fi
+echo ".SRCINFO generated at $srcinfo_path"
+cat "$srcinfo_path"
+
+# --- Update repo-root PKGBUILD/.SRCINFO for PR ---
+# Only overwrite root if we have a real checksum (not SKIP) — preserve last good PKGBUILD for AUR
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ $appimage_sha != "SKIP" ]]; then
+  echo "Updating repo-root PKGBUILD/.SRCINFO at $project_root ..."
+  cp "$pkgbuild_path" "$project_root/PKGBUILD"
+  cp "$desktop_file_src" "$project_root/figma-desktop.desktop"
+  cp "$srcinfo_path" "$project_root/.SRCINFO"
+  echo "Repo-root files updated."
+else
+  echo "Skipping repo-root update (appimage SHA is SKIP — no release artifact yet, keeping existing PKGBUILD)"
+  echo "Generated files remain in $work_dir/PKGBUILD + .SRCINFO for inspection"
+fi
+
+# --- Optionally build binary pacman package via makepkg ---
+if command -v makepkg &>/dev/null; then
+  echo "Building .pkg.tar.zst via makepkg..."
+  # makepkg refuses to run as root without --asdeps; handle it
+  makepkg_args=(-f --noconfirm)
+  if (( EUID == 0 )); then
+    makepkg_args+=(--asdeps --allow-dependency-resolution)
+    # On some systems makepkg still refuses as root — try with --asroot if available or warn
+    if ! (cd "$work_dir" && makepkg "${makepkg_args[@]}"); then
+      echo "makepkg as root failed — trying with su to nobody or skipping binary build"
+      # Don't fail the whole build; PKGBUILD/.SRCINFO are already generated
+      echo "PKGBUILD/.SRCINFO are ready. Build binary manually with: cd $work_dir && makepkg"
+      exit 0
+    fi
+  else
+    (cd "$work_dir" && makepkg "${makepkg_args[@]}")
+  fi
+  pkg_file=$(find "$work_dir" -maxdepth 1 -name "*.pkg.tar.zst" | head -n 1)
+  if [[ -n $pkg_file ]]; then
+    echo "Pacman package built: $pkg_file"
+  else
+    echo "Warning: makepkg finished but no .pkg.tar.zst found in $work_dir"
+  fi
+else
+  echo "makepkg not found — skipping binary .pkg.tar.zst build."
+  echo "Install pacman/makepkg on Arch, or run: cd $work_dir && makepkg"
+fi
+
+echo '--- Pacman Package Build Finished ---'


### PR DESCRIPTION
## Summary
Adds Arch as a first-class build target alongside `deb`/`rpm`/`AppImage`.

## Changes
* **AUR `figma-desktop-bin`** is an AppImage wrapper
  * `PKGBUILD`, `figma-desktop.desktop`, `.SRCINFO`
  * Static `pkgver`, source `https://github.com/IliyaBrook/figma-linux/releases/download/<ver>/figma-desktop-<ver>-amd64.AppImage`

* **Build system**
  * `scripts/build-pacman-package.sh` uses same interface as `build-deb-package.sh` / `build-rpm-package.sh`, generates `PKGBUILD`/`.SRCINFO` and builds `*.pkg.tar.zst` via `makepkg`
  * `build.sh` now detect `arch` (`/etc/arch-release`), `--build pacman`, `makepkg` deps
  * `Makefile` includes `make build-pacman` and `make clean` now removes `src/` `pkg/` `*.pkg.tar.zst`
  * `.gitignore` also ignore `src/` `pkg/` which is used for building arch package

Existing `deb`/`rpm`/`AppImage` flows unchanged.

## Usage
```bash
make build-pacman        # or ./build.sh --build pacman
makepkg -si              # directly from repo root (AUR)
```
## Verified
- makepkg --printsrcinfo ok
- makepkg -si 126.5.6-1 download/validate/package/install ok
