### PR TITLE
fix: unblock building from source (7z detection, asar pin) + Electron version override

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -584,7 +584,10 @@ detect_electron_version() {
 			| head -1 | sed 's|Electron/||')
 	fi
 
-	if [[ -n $detected ]]; then
+	if [[ -n ${FIGMA_ELECTRON_VERSION:-} ]]; then
+		electron_version="$FIGMA_ELECTRON_VERSION"
+		echo "Using Electron version override: $electron_version (detected: ${detected:-none})"
+	elif [[ -n $detected ]]; then
 		electron_version="$detected"
 		echo "Detected Electron version from Figma.exe: $electron_version"
 	else

--- a/build.sh
+++ b/build.sh
@@ -244,7 +244,7 @@ parse_arguments() {
 check_dependencies() {
 	echo 'Checking dependencies...'
 	local deps_to_install=''
-	local common_deps='p7zip wget convert'
+	local common_deps='7z wget convert'
 	local all_deps="$common_deps"
 
 	# Add format-specific dependencies
@@ -255,12 +255,12 @@ check_dependencies() {
 
 	# Command-to-package mappings per distro family
 	declare -A debian_pkgs=(
-		[p7zip]='p7zip-full' [wget]='wget'
+		[7z]='p7zip-full' [wget]='wget'
 		[convert]='imagemagick'
 		[dpkg-deb]='dpkg-dev' [rpmbuild]='rpm'
 	)
 	declare -A rpm_pkgs=(
-		[p7zip]='p7zip p7zip-plugins' [wget]='wget'
+		[7z]='7zip' [wget]='wget'
 		[convert]='ImageMagick'
 		[dpkg-deb]='dpkg' [rpmbuild]='rpm-build'
 	)

--- a/build.sh
+++ b/build.sh
@@ -419,7 +419,8 @@ setup_electron_asar() {
 
 	if [[ $install_needed == true ]]; then
 		echo "Installing Electron $electron_version and Asar locally into $work_dir..."
-		if ! npm install --no-save "electron@$electron_version" @electron/asar; then
+		# asar 4.2.1+ rejects Figma's app.asar header (/.codesign has size -1000).
+		if ! npm install --no-save "electron@$electron_version" "@electron/asar@${FIGMA_ASAR_VERSION:-4.2.0}"; then
 			echo 'Failed to install Electron and/or Asar locally.' >&2
 			cd "$project_root" || exit 1
 			exit 1


### PR DESCRIPTION
## Summary

Three fixes to `build.sh` for building from source. The first two are build blockers; the third is a small escape hatch.

| # | Change | Impact |
|---|--------|--------|
| 1 | Check for `7z`, not `p7zip` | Fedora 40+ cannot build at all |
| 2 | Pin `@electron/asar` to 4.2.0 | **All** source builds currently fail |
| 3 | Add `FIGMA_ELECTRON_VERSION` | Opt-in only, no default change |

## 1. `p7zip` dependency check fails on Fedora

`check_dependencies` looks for a command named `p7zip`, but the script actually invokes `7z` (build.sh L534, L558). Fedora 40+ ships that binary in the `7zip` package and provides no `p7zip` command, so the check fails even when `7z` is installed and present in `PATH`:

```
Checking dependencies...
p7zip not found
System dependencies needed: p7zip p7zip-plugins
```

It then tries to install `p7zip p7zip-plugins`, which no longer exist on Fedora 44. Now checks `7z` and maps it to `7zip` (rpm) / `p7zip-full` (debian) — both provide `/usr/bin/7z`.

## 2. Unpinned `@electron/asar` breaks every build

`@electron/asar` was installed unpinned. **4.2.1** added strict asar header validation that rejects Figma's `app.asar`, whose `/.codesign` entry carries a negative size:

```
HeaderValidationError: Invalid archive header at "/.codesign":
"size" must be a non-negative number, got -1000
    at validateFileEntry (.../@electron/asar/lib/disk.js:22:15)
```

This is independent of distro and Electron version, so any build from a clean checkout fails today. Bisected against Figma 126.8.16's `app.asar`:

| @electron/asar | `getRawHeader()` |
|---|---|
| 3.4.1 | OK |
| 4.0.0 | OK |
| 4.1.0 / 4.1.2 / 4.2.0 | OK |
| **4.2.1** | **HeaderValidationError** |
| 4.3.0 | HeaderValidationError |

Pinned to 4.2.0, the newest release that reads the archive. `FIGMA_ASAR_VERSION` lifts the pin once upstream accepts the header again, so this does not need a code change to undo.

## 3. `FIGMA_ELECTRON_VERSION` override

`detect_electron_version` reads the version embedded in `Figma.exe`, which is the correct default and is unchanged. This adds an opt-in override for when the detected Electron is unusable on a particular host.

Concretely: on Fedora 44 with Mesa 26.0.3, the Chromium bundled with the detected Electron renders the Figma canvas as corrupted fragments while the UI chrome draws correctly. Building with a newer Electron resolves it. Details and full elimination steps in the linked issue.

```bash
FIGMA_ELECTRON_VERSION=44.0.0 ./build.sh --build appimage
```

Logs both values so build output stays diagnosable:

```
Using Electron version override: 44.0.0 (detected: 42.9.2)
```

## Testing

Fedora 44 (KDE, Wayland), x86_64, Mesa 26.0.3, Node 22.23.1.

- **Stock build, no env vars** — auto-detected Electron 42.9.2, asar 4.2.0: AppImage builds and runs. This confirms fixes 1 and 2 alone unblock the build.
- **With `FIGMA_ELECTRON_VERSION=44.0.0`** — AppImage builds; canvas renders correctly with hardware acceleration; sign-in works.
- `bash -n build.sh` clean.

## Notes

- Default behavior is unchanged when neither env var is set.
- Commits are atomic, one per fix.
- Unrelated but worth flagging: `build.sh` L331 runs `rm -rf "$work_dir"` at startup, so `build/` is wiped on every run and `--clean no` only governs post-build cleanup. A cached `FigmaSetup.exe` inside `build/` is deleted before the `--exe` check reads it. Not touched here — happy to send a separate PR if you want `--exe` to survive.
