### PR TITLE
fix: add Arch/pacman support and FUSE2 prerequisite for AppImage builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ chmod +x figma-desktop-*.AppImage
 ./figma-desktop-*.AppImage
 ```
 
+#### FUSE requirement
+
+The AppImage mounts itself with **FUSE2** (`libfuse.so.2`). Most modern distributions ship only **FUSE3**, which is **not** a substitute, so you may need to install FUSE2 first:
+
+| Distribution                | Install command                   |
+| --------------------------- | --------------------------------- |
+| Arch / Manjaro              | `sudo pacman -S fuse2`            |
+| Ubuntu 22.04                | `sudo apt install libfuse2`       |
+| Ubuntu 24.04+ / Debian 13+  | `sudo apt install libfuse2t64`    |
+| Fedora / RHEL               | `sudo dnf install fuse fuse-libs` |
+
+If you can't install FUSE2, run the AppImage with `--appimage-extract-and-run` — it extracts and runs without FUSE:
+
+```bash
+./figma-desktop-*.AppImage --appimage-extract-and-run
+```
+
+> **Important:** Without FUSE2, the `figma://` browser login hand-off fails **silently** — the protocol-handler launch can't mount the AppImage, the OAuth token never reaches the app, and it stays stuck on the login screen. Install FUSE2 (or use `--appimage-extract-and-run`) to make browser login complete.
+
 On first launch the AppImage automatically:
 
 - Creates a `.desktop` entry in `~/.local/share/applications/`
@@ -86,8 +105,9 @@ This covers the normal font picker and the **Installed by you** flow. If you alr
 - **p7zip** — for extracting the Windows installer
 - **ImageMagick** — for icon conversion
 - **wget** — for downloading the installer
+- **FUSE2** (`libfuse2`/`fuse2`) — for AppImage builds; `appimagetool` is itself an AppImage and needs `libfuse.so.2` to run
 
-> The build script auto-detects missing dependencies and installs them via `apt` (Debian/Ubuntu) or `dnf` (Fedora/RHEL).
+> The build script auto-detects missing dependencies and installs them via `apt` (Debian/Ubuntu), `dnf` (Fedora/RHEL), or `pacman` (Arch).
 
 #### Build & Run
 

--- a/build.sh
+++ b/build.sh
@@ -58,6 +58,37 @@ check_command() {
 	fi
 }
 
+check_fuse2() {
+	# The bundled AppImage runtime requires the FUSE2 userspace library
+	# (libfuse.so.2). Detect the library directly instead of a command name:
+	# several distros ship fuse3 (libfuse.so.3) but not fuse2, and fuse3 is
+	# NOT a substitute. libfuse.so.2 is also needed at build time because
+	# appimagetool is itself distributed as an AppImage.
+	if ldconfig -p 2>/dev/null | grep -q 'libfuse\.so\.2'; then
+		echo "fuse2 library (libfuse.so.2) found"
+		return 0
+	fi
+	echo "fuse2 library (libfuse.so.2) not found"
+	return 1
+}
+
+# Echo the distro-specific package(s) providing FUSE2 (libfuse.so.2).
+fuse2_pkg_for_distro() {
+	case "$distro_family" in
+		debian)
+			# Ubuntu >= 24.04 / Debian >= 13 renamed libfuse2 -> libfuse2t64
+			if grep -qE '^VERSION_ID="(2[4-9]|1[3-9])' /etc/os-release 2>/dev/null; then
+				echo 'libfuse2t64'
+			else
+				echo 'libfuse2'
+			fi
+			;;
+		rpm) echo 'fuse fuse-libs' ;;
+		arch) echo 'fuse2' ;;
+		*) echo '' ;;
+	esac
+}
+
 section_header() {
 	echo -e "\033[1;36m--- $1 ---\033[0m"
 }
@@ -109,6 +140,9 @@ detect_distro() {
 	elif [[ -f /etc/redhat-release ]]; then
 		distro_family='rpm'
 		echo "Detected Red Hat-based distribution"
+	elif [[ -f /etc/arch-release ]] || grep -qE '^ID(_LIKE)?=(")?arch(")?' /etc/os-release 2>/dev/null; then
+		distro_family='arch'
+		echo "Detected Arch-based distribution"
 	else
 		distro_family='unknown'
 		echo "Warning: Could not detect distribution family"
@@ -253,6 +287,12 @@ check_dependencies() {
 		rpm) all_deps="$all_deps rpmbuild" ;;
 	esac
 
+	# AppImage builds run appimagetool (itself an AppImage) and produce an
+	# AppImage whose runtime dlopens libfuse.so.2, so FUSE2 must be present.
+	if [[ $build_format == 'appimage' ]] && ! check_fuse2; then
+		all_deps="$all_deps fuse2"
+	fi
+
 	# Command-to-package mappings per distro family
 	declare -A debian_pkgs=(
 		[p7zip]='p7zip-full' [wget]='wget'
@@ -264,16 +304,36 @@ check_dependencies() {
 		[convert]='ImageMagick'
 		[dpkg-deb]='dpkg' [rpmbuild]='rpm-build'
 	)
+	declare -A arch_pkgs=(
+		[p7zip]='p7zip' [wget]='wget'
+		[convert]='imagemagick'
+		[fuse2]='fuse2'
+	)
 
 	local cmd
 	for cmd in $all_deps; do
 		if ! check_command "$cmd"; then
 			case "$distro_family" in
 				debian)
-					deps_to_install="$deps_to_install ${debian_pkgs[$cmd]}"
+					if [[ $cmd == 'fuse2' ]]; then
+						deps_to_install="$deps_to_install $(fuse2_pkg_for_distro)"
+					else
+						deps_to_install="$deps_to_install ${debian_pkgs[$cmd]}"
+					fi
 					;;
 				rpm)
-					deps_to_install="$deps_to_install ${rpm_pkgs[$cmd]}"
+					if [[ $cmd == 'fuse2' ]]; then
+						deps_to_install="$deps_to_install $(fuse2_pkg_for_distro)"
+					else
+						deps_to_install="$deps_to_install ${rpm_pkgs[$cmd]}"
+					fi
+					;;
+				arch)
+					if [[ -n ${arch_pkgs[$cmd]:-} ]]; then
+						deps_to_install="$deps_to_install ${arch_pkgs[$cmd]}"
+					else
+						echo "Warning: No Arch package mapping for '$cmd'. Please install manually." >&2
+					fi
 					;;
 				*)
 					echo "Warning: Cannot auto-install '$cmd' on unknown distro. Please install manually." >&2
@@ -314,6 +374,13 @@ check_dependencies() {
 				# shellcheck disable=SC2086
 				if ! $sudo_cmd dnf install -y $deps_to_install; then
 					echo "Failed to install dependencies using 'dnf install'." >&2
+					exit 1
+				fi
+				;;
+			arch)
+				# shellcheck disable=SC2086
+				if ! $sudo_cmd pacman -S --noconfirm $deps_to_install; then
+					echo "Failed to install dependencies using 'pacman -S'." >&2
 					exit 1
 				fi
 				;;


### PR DESCRIPTION
## What

Fixes AppImage failures on systems without **FUSE2** (`libfuse.so.2`), which causes the `figma://` browser login hand-off to fail **silently** (issue #16: "Logging in with browser makes me log in over and over again and never completes"), and adds Arch/pacman dependency auto-install (issue #21).

### Changes

**`build.sh`**
- `detect_distro()`: detect Arch via `/etc/arch-release` or `ID`/`ID_LIKE=arch` in `/etc/os-release`.
- `check_dependencies()`:
  - New `check_fuse2()` — detects the **library** `libfuse.so.2` via `ldconfig -p` (not a command name), because fuse3 is not a substitute.
  - When building an AppImage, queue a distro-appropriate FUSE2 package if missing (Arch `fuse2`, Ubuntu 22.04 `libfuse2`, Ubuntu 24.04+/Debian 13+ `libfuse2t64`, Fedora `fuse fuse-libs`).
  - New `arch_pkgs` mapping + `pacman -S --noconfirm` install branch.

**`README.md`**
- Documents the FUSE2 requirement with per-distro install commands and the `--appimage-extract-and-run` fallback.
- Explains the silent browser-login failure mode caused by missing FUSE2.
- Updates build prerequisites + auto-install note to include `pacman`.

## Why

The bundled AppImage runtime dlopens `libfuse.so.2`. When FUSE2 is absent (common on Arch, Fedora 35+, Ubuntu 22.04+/Debian 13+), the runtime exits before `AppRun` runs. The AppImage never launches, so the `.desktop`/`figma://` hand-off that carries the OAuth token from the browser never fires — the app stays on the login screen. `appimagetool` (also an AppImage) likewise can't run at build time.

## Testing (Arch / Omarchy)

- `bash -n build.sh` passes.
- `detect_distro` → `arch`; `check_fuse2` correctly reports present/absent; `fuse2_pkg_for_distro` returns the right package per distro/version.
- Dry-run `check_dependencies` (appimage, all commands stubbed missing) queues `p7zip wget imagemagick` and installs via `pacman -S --noconfirm`.
- End-to-end: with `fuse2` installed, browser login + OAuth hand-off to the desktop app completes successfully.

## Related

- Fixes #16
- Fixes #21
- Partially addresses #13 (outdated AppImage runtime — the produced AppImage still needs FUSE2 until a static/FUSE3-capable runtime is bundled; tracked separately)