### PR TITLE
feat: bundle type2 static AppImage runtime (FUSE2 + FUSE3)

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -248,6 +248,10 @@ echo "AppStream metadata created"
 
 # --- Get appimagetool ---
 appimagetool_path=''
+# When appimagetool is the official AppImage, run it via --appimage-extract-and-run
+# so the build does NOT require FUSE2 on the host. Native/system installs are
+# invoked directly.
+appimagetool_extract_run=''
 
 if command -v appimagetool &> /dev/null; then
 	appimagetool_path=$(command -v appimagetool)
@@ -259,6 +263,7 @@ for arch in x86_64 aarch64; do
 	local_path="$work_dir/appimagetool-${arch}.AppImage"
 	if [[ -f $local_path ]]; then
 		appimagetool_path="$local_path"
+		appimagetool_extract_run='--appimage-extract-and-run'
 		echo "Found downloaded ${arch} appimagetool: $appimagetool_path"
 	fi
 done
@@ -276,6 +281,7 @@ if [[ -z $appimagetool_path ]]; then
 
 	appimagetool_url="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${tool_arch}.AppImage"
 	appimagetool_path="$work_dir/appimagetool-${tool_arch}.AppImage"
+	appimagetool_extract_run='--appimage-extract-and-run'
 
 	if wget -q -O "$appimagetool_path" "$appimagetool_url"; then
 		chmod +x "$appimagetool_path" || exit 1
@@ -287,6 +293,30 @@ if [[ -z $appimagetool_path ]]; then
 	fi
 fi
 
+# --- Get the type2 AppImage runtime (static, supports both FUSE2 and FUSE3) ---
+# The classic appimagetool runtime dlopens libfuse.so.2 and fails on distros
+# that ship only libfuse3 (Arch, Fedora 35+, Ubuntu 22.04+/Debian 13+). The
+# type2-runtime statically links libfuse/squashfuse and mounts through either
+# fusermount (FUSE2) or fusermount3 (FUSE3), so the produced AppImage runs on
+# FUSE3-only systems out of the box.
+runtime_arch="${tool_arch:-x86_64}"
+runtime_path="$work_dir/appimage-runtime-${runtime_arch}"
+runtime_file_arg=''
+if [[ -f $runtime_path ]]; then
+	echo "Found downloaded type2 runtime: $runtime_path"
+	runtime_file_arg="--runtime-file $runtime_path"
+else
+	runtime_url="https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-${runtime_arch}"
+	if wget -q -O "$runtime_path" "$runtime_url"; then
+		chmod +x "$runtime_path" || exit 1
+		echo "Downloaded type2 runtime to $runtime_path"
+		runtime_file_arg="--runtime-file $runtime_path"
+	else
+		echo "Warning: Failed to download type2 runtime; appimagetool's default FUSE2 runtime will be used." >&2
+		rm -f "$runtime_path"
+	fi
+fi
+
 # --- Build AppImage ---
 echo 'Building AppImage...'
 output_filename="${package_name}-${version}-${architecture}.AppImage"
@@ -295,7 +325,8 @@ export ARCH="$architecture"
 echo "Using ARCH=$ARCH"
 
 echo 'Building AppImage without update information'
-if ! "$appimagetool_path" "$appdir_path" "$output_path"; then
+# shellcheck disable=SC2086
+if ! "$appimagetool_path" $appimagetool_extract_run $runtime_file_arg "$appdir_path" "$output_path"; then
 	echo "Failed to build AppImage using $appimagetool_path" >&2
 	exit 1
 fi


### PR DESCRIPTION
> **Draft** — please do not merge yet. This is the root-fix follow-up to #24 (PR1) for the AppImage FUSE2 dependency.

## What

Rebuilds the AppImage with the maintained **type2-runtime** ([AppImage/type2-runtime](https://github.com/AppImage/type2-runtime)) instead of appimagetool's classic runtime.

## Why

The classic runtime `dlopen`s `libfuse.so.2` and exits before `AppRun` ever runs on distros that ship only `libfuse3` (Arch, Fedora 35+, Ubuntu 22.04+/Debian 13+). Because the `.desktop`/`figma://` protocol-handler launch is what carries the OAuth token back from browser login, this makes login silently loop forever (issue #16). PR1 (#24) documents/installs FUSE2; this PR removes the dependency at the source (issue #13).

## Changes

**`scripts/build-appimage.sh`**
- Run the `appimagetool` AppImage via `--appimage-extract-and-run`, so **building** no longer needs FUSE2 either.
- Download `AppImage/type2-runtime` `runtime-<arch>` and pass `--runtime-file`, so the **produced AppImage** uses a static runtime (embedded libfuse + squashfuse) that mounts through **either** `fusermount` (FUSE2) **or** `fusermount3` (FUSE3).

## Verification

Built a minimal test AppImage with `appimagetool --appimage-extract-and-run --runtime-file <type2-runtime>`:

- Runs normally with FUSE2 (`fusermount`) present.
- **Runs on a FUSE3-only PATH** (only `bash` + `fusermount3` available, no `fusermount`/`libfuse.so.2`) — exit 0.

## Open questions for review

- Pin the type2-runtime to a tagged release instead of `continuous`? (Continuous is currently the only published stream.)
- Should the runtime be vendored/cached like `appimagetool-<arch>.AppImage` is today? (Currently cached per-build in `$work_dir`.)
- Figma is x86_64-only, so the `aarch64` path is untested.